### PR TITLE
Compare date types with strongly typed names

### DIFF
--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -441,8 +441,8 @@ export class OptionConverter {
    * @private
    */
   static _dateTypeCheck(d: any): DateTime | null {
-    if (d.constructor.name === 'DateTime') return d;
-    if (d.constructor.name === 'Date') {
+    if (d.constructor.name === DateTime.name) return d;
+    if (d.constructor.name === Date.name) {
       return DateTime.convert(d);
     }
     if (typeof d === typeof '') {


### PR DESCRIPTION
Many JavaScript frameworks and bundlers minify code when building for production.
Minification includes renaming identifiers, including class names.

Comparing types using literal string names doesn't work well with these frameworks and bundlers.
For example, SvelteKit renames `DateTime` to something like `Ve`.
With this, the `if` test fails because 'Ve' is not the same as 'DateTime'.

This results in exceptions such as the following:
- Error: TD: Could not correctly parse "Sun Oct 03 2021 11:15:46 GMT+0000 (Coordinated Universal Time)" to a date for defaultDate
- Error: TD: Could not correctly parse "Sun Oct 03 2021 11:15:46 GMT+0000 (Coordinated Universal Time)" to a date for viewDate

With this change, in the minified file, the line now tests for `Ve.name` instead of 'DateTime'