### PR TITLE
fix reshow should not call dates.setValue with the current

### DIFF
--- a/src/js/display/index.ts
+++ b/src/js/display/index.ts
@@ -143,31 +143,32 @@ export default class Display {
    */
   show(): void {
     if (this.widget == undefined) {
-      if (
-        this.optionsStore.options.useCurrent &&
-        !this.optionsStore.options.defaultDate &&
-        !this.optionsStore.input?.value
-      ) {
-        const date = new DateTime().setLocale(
-          this.optionsStore.options.localization.locale
-        );
-        if (!this.optionsStore.options.keepInvalid) {
-          let tries = 0;
-          let direction = 1;
-          if (this.optionsStore.options.restrictions.maxDate?.isBefore(date)) {
-            direction = -1;
+     if (this.dates.picked.length == 0) {
+          if (
+            this.optionsStore.options.useCurrent &&
+            !this.optionsStore.options.defaultDate
+          ) {
+            const date = new DateTime().setLocale(
+              this.optionsStore.options.localization.locale
+            );
+            if (!this.optionsStore.options.keepInvalid) {
+              let tries = 0;
+              let direction = 1;
+              if (this.optionsStore.options.restrictions.maxDate?.isBefore(date)) {
+                direction = -1;
+              }
+              while (!this.validation.isValid(date)) {
+                date.manipulate(direction, Unit.date);
+                if (tries > 31) break;
+                tries++;
+              }
+            }
+            this.dates.setValue(date);
           }
-          while (!this.validation.isValid(date)) {
-            date.manipulate(direction, Unit.date);
-            if (tries > 31) break;
-            tries++;
+    
+          if (this.optionsStore.options.defaultDate) {
+            this.dates.setValue(this.optionsStore.options.defaultDate);
           }
-        }
-        this.dates.setValue(date);
-      }
-
-      if (this.optionsStore.options.defaultDate) {
-        this.dates.setValue(this.optionsStore.options.defaultDate);
       }
 
       this._buildWidget();


### PR DESCRIPTION
fixes https://github.com/Eonasdan/tempus-dominus/issues/2493

when a reshow is done, especially with inline calender
the useCurrent or useDefault should not be used if there is already
someting in the dates.
If there is already a date set, but then you update some options it
should stick to that date, not reset to the current or default..