### PR TITLE
Fixes use of SVG icons (issue #2527)

### DIFF
--- a/src/js/display/index.ts
+++ b/src/js/display/index.ts
@@ -651,10 +651,15 @@ export default class Display {
    * @param iconClass
    * @private
    */
-  _iconTag(iconClass: string): HTMLElement {
+  _iconTag(iconClass: string): HTMLElement|SVGElement {
     if (this.optionsStore.options.display.icons.type === 'sprites') {
-      const svg = document.createElement('svg');
-      svg.innerHTML = `<use xlink:href='${iconClass}'></use>`;
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+
+      const icon = document.createElementNS('http://www.w3.org/2000/svg', 'use');
+      icon.setAttribute('xlink:href', iconClass); // Deprecated. Included for backward compatibility
+      icon.setAttribute('href', iconClass);
+      svg.appendChild(icon);
+      
       return svg;
     }
     const icon = document.createElement('i');


### PR DESCRIPTION
- Create SVG elements in correct namespace
- Add standard `href` tag to `use` element. Maintain deprecated `xlink:href` for backward compatibility.

See:
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href
https://svgwg.org/svg2-draft/linking.html#XLinkRefAttrs