### PR TITLE
Trigger native change event on input when available - fixes #2401

### DIFF
--- a/src/js/tempus-dominus.ts
+++ b/src/js/tempus-dominus.ts
@@ -254,6 +254,10 @@ class TempusDominus {
       this.optionsStore.input?.dispatchEvent(
         new CustomEvent(event.type, { detail: event as any })
       );
+
+      this.optionsStore.input?.dispatchEvent(
+          new CustomEvent('change', { detail: event as any })
+      );
     }
 
     this.optionsStore.element.dispatchEvent(
@@ -463,7 +467,10 @@ class TempusDominus {
    * something for the remove listener function.
    * @private
    */
-  private _inputChangeEvent = () => {
+  private _inputChangeEvent = (event?: any) => {
+    const internallyTriggered = event?.detail;
+    if (internallyTriggered) return;
+
     const setViewDate = () => {
       if (this.dates.lastPicked)
         this.optionsStore.viewDate = this.dates.lastPicked;


### PR DESCRIPTION
This PR triggers a native change event on an underlying input when available.

When an `input` element is updated, a native change event should be triggered. This allows client code to exist without needing explicit knowledge of the date picker used under the hood. Many change events (validation, chaining updates from one input to another, etc.) can and should be agnostic to the plugins (if any) that drive them.

This PR retains the default namespaced events to avoid a breaking change as well as allow plugin specific listeners.