### PR TITLE
Check for view mode configuration when showing picker

### DIFF
--- a/src/js/display/index.ts
+++ b/src/js/display/index.ts
@@ -177,11 +177,11 @@ export default class Display {
 
       this._buildWidget();
 
-      // If modeView is only clock
-      const onlyClock = this._hasTime && !this._hasDate;
+      // If there are no date components or the "clock" view mode is configured.
+      const clockViewMode = (this._hasTime && !this._hasDate) || this.optionsStore.options.display.viewMode == 'clock';
 
-      // reset the view to the clock if there's no date components
-      if (onlyClock) {
+      // Reset the view to clock if in "clock" view mode.
+      if (clockViewMode) {
         this.optionsStore.currentView = 'clock';
         this._eventEmitters.action.emit({
           e: null,
@@ -195,7 +195,7 @@ export default class Display {
           this.optionsStore.minimumCalendarViewMode;
       }
 
-      if (!onlyClock) {
+      if (!clockViewMode) {
         if (this._hasTime) {
           Collapse.hide(
             this.widget.querySelector(`div.${Namespace.css.timeContainer}`)


### PR DESCRIPTION
PRs relating to the v4 will be closed and locked.

* **Please check if the PR fulfills these requirements**
- [x] The PR is against the `development` branch
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...). If this is a fix, please tag a bug.

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Setting the `viewMode` to `clock` uses the `calendar` view mode if dates are enabled. (#2583)

* **What is the new behavior (if this is a feature change)?**

Setting the `viewMode` to `clock` uses the `clock` view mode regardless of whether or not dates are enabled.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

Fixes #2583