### PR TITLE
Fixing double calendar on toggle picker issue (#2594)

### DIFF
--- a/src/js/actions.ts
+++ b/src/js/actions.ts
@@ -192,7 +192,7 @@ export default class Actions {
                         this.optionsStore.options.display.icons.date
                     ).outerHTML;
                     if (this.display._hasTime) {
-                        this.do(e, ActionTypes.showClock);
+                        this.handleShowClockContainers(ActionTypes.showClock);
                         this.display._update('clock');
                     }
                 }


### PR DESCRIPTION
PRs relating to the v4 will be closed and locked.

* **Please check if the PR fulfills these requirements**
- [ ✔️ ] The PR is against the `development` branch
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ✔️ ] Does NOT modify files under the "dist" folder.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...). If this is a fix, please tag a bug.

Bug fix for #2594 

* **What is the current behavior?** (You can also link to an open issue here)

Currently... when not in side-by-side, the picker has time, and the initial view is the calendar, clicking on the toggle button (title: Select Time icon: clock) shows the calendar again but the toggle button changes (title: Select Date icon: calendar). From then on it toggles correctly but the icon and title of the toggle button are inversed.

* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No... it fixes it to work as expected

* **Other information**:
