### PR TITLE
adding placement option

### DIFF
--- a/src/docs/partials/options/display.html
+++ b/src/docs/partials/options/display.html
@@ -406,6 +406,15 @@
     </p>
   </div>
 
+  <div class='row'>
+    <h2 id='placement'>placement<a class='anchor-link' aria-label='Anchor' href='#placement'><i
+      class='fa-solid fa-anchor' aria-hidden='true'></i></a></h2>
+    <p>
+      <strong>Accepts:</strong> 'top' | 'bottom' <strong>Defaults:</strong> 'bottom'<br />
+      Specifies whether the picker should be displayed at the top or bottom of the element passed to the picker instance.
+    </p>
+  </div>
+
   <div id='subToc' class='d-none'>
     <nav id='TableOfContents'>
       <ul>
@@ -452,6 +461,7 @@
           </ul></li>
         <li><a href='#inline'>Inline</a></li>
         <li><a href='#theme'>Theme</a></li>
+        <li><a href='#placement'>Placement</a></li>
       </ul>
     </nav>
   </div>

--- a/src/js/display/index.ts
+++ b/src/js/display/index.ts
@@ -171,14 +171,16 @@ export default class Display {
       if (!this.optionsStore.options.display.inline) {
         // If needed to change the parent container
         const container = this.optionsStore.options?.container || document.body;
+        const placement = this.optionsStore.options?.display?.placement || 'bottom';
+
         container.appendChild(this.widget);
         this.createPopup(this.optionsStore.element, this.widget, {
           modifiers: [{ name: 'eventListeners', enabled: true }],
           //#2400
           placement:
             document.documentElement.dir === 'rtl'
-              ? 'bottom-end'
-              : 'bottom-start',
+              ? `${placement}-end`
+              : `${placement}-start`,
         }).then();
       } else {
         this.optionsStore.element.appendChild(this.widget);

--- a/src/js/utilities/default-options.ts
+++ b/src/js/utilities/default-options.ts
@@ -45,6 +45,7 @@ const DefaultOptions: Options = {
     },
     inline: false,
     theme: 'auto',
+    placement: 'bottom',
   },
   keepInvalid: false,
   localization: {

--- a/src/js/utilities/optionProcessor.ts
+++ b/src/js/utilities/optionProcessor.ts
@@ -134,6 +134,7 @@ const optionProcessors: { [key: string]: OptionProcessorFunction } =
       'decades',
     ]),
     theme: validKeyOption(['light', 'dark', 'auto']),
+    placement: validKeyOption(['top', 'bottom']),
     meta: ({ value }) => value,
     dayViewHeaderFormat: ({ value }) => value,
     container: ({ value, path }) => {

--- a/src/js/utilities/options.ts
+++ b/src/js/utilities/options.ts
@@ -40,6 +40,7 @@ export default interface Options {
     inline?: boolean;
     keepOpen?: boolean;
     theme?: 'light' | 'dark' | 'auto';
+    placement?: 'top' | 'bottom';
   };
   keepInvalid?: boolean;
   localization?: Localization;


### PR DESCRIPTION
PRs relating to the v4 will be closed and locked.

* **Please check if the PR fulfills these requirements**
- [✔︎] The PR is against the `development` branch
- [ ] Tests for the changes have been added (for bug fixes / features)
- [✔︎] Docs have been added / updated (for bug fixes / features)
- [✔︎] Does NOT modify files under the "dist" folder.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...). If this is a fix, please tag a bug.

This adds a feature to specify the initial placement for the widget when not inline. 

* **What is the current behavior?** (You can also link to an open issue here)

Although Popper JS seems to handle the placement of the widget every other time, the initial placement was hardcoded to `bottom-*` in `src/js/display/index.js`. If the widget is towards the bottom of the page, the initial toggle will have the picker cutoff. Subsequent toggles will move the widget to the top of the element instead and the full picker will be shown.

* **What is the new behavior (if this is a feature change)?**

The new behavior allows the initial placement to be specified so, in cases where you know the picker is at the bottom of the page, it can instead be shown at the top of the element and not get cutoff.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, the default for the new option is `bottom` which is the current behavior

* **Other information**:

I don't see any tests around other options so I've not added any tests around this new one.