### PR TITLE
fixing infinity loop bug in date range

### DIFF
--- a/src/js/validation.ts
+++ b/src/js/validation.ts
@@ -203,8 +203,14 @@ export default class Validation {
     // because the other validation on the target has already occurred.
     if (dates.length !== 2 && index !== 1) return true;
 
+    // initialize start date
+    const start = dates[0];
+
+    // check if start date is not the same as target date
+    if(start.isSame(target, Unit.date)) return true;
+    
     // add one day to start; start has already been validated
-    const start = dates[0].clone.manipulate(1, Unit.date);
+    start.clone.manipulate(1, Unit.date);
 
     // check each date in the range to make sure it's valid
     while (!start.isSame(target, Unit.date)) {


### PR DESCRIPTION
- [x] The PR is against the `development` branch
- [x] Does NOT modify files under the "dist" folder.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...). If this is a fix, please tag a bug.
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
When dealing with date range and selecting the same date as start/end date it causes an infinite loop and browser crash.


* **What is the new behavior (if this is a feature change)?**
As the problem was because of assuming that end date is always after start date, the start date was being incremented by 1 day before the for loop compare with the end date happens, causing the start date to be after the end date if it was the same day, hence the infinity loop.

The fix separates the increment from the initialization of the start variable and comparing if it's the same before the increment step and the for loop.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

