### PR TITLE
Add type attribute to meridiem button

### DIFF
--- a/src/js/display/time/time-display.ts
+++ b/src/js/display/time/time-display.ts
@@ -294,6 +294,7 @@ export default class TimeDisplay {
       top.push(divElement);
 
       const button = document.createElement('button');
+      button.setAttribute('type', 'button'); 
       button.setAttribute(
         'title',
         this.optionsStore.options.localization.toggleMeridiem


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The PR is against the `development` branch
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [X] Does NOT modify files under the "dist" folder.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...). If this is a fix, please tag a bug.
Add `type='button'` attribute to meridiem `button` element to toggle AM/PM

* **What is the current behavior?** (You can also link to an open issue here)
Resolves the current behavior described at https://github.com/Eonasdan/tempus-dominus/issues/2820

* **What is the new behavior (if this is a feature change)?**
Always add `type='button'` attribute to meridiem `button` element to toggle AM/PM

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking change.

* **Other information**:
None
