### PR TITLE
Fix where minDate would be a reference of viewDate instead of declaring it's own date

### DIFF
--- a/src/js/tempus-dominus.ts
+++ b/src/js/tempus-dominus.ts
@@ -418,13 +418,13 @@ class TempusDominus {
       newConfig.restrictions.maxDate &&
       this.viewDate.isAfter(newConfig.restrictions.maxDate)
     )
-      this.viewDate = newConfig.restrictions.maxDate;
+      this.viewDate = newConfig.restrictions.maxDate.clone;
 
     if (
       newConfig.restrictions.minDate &&
       this.viewDate.isBefore(newConfig.restrictions.minDate)
     )
-      this.viewDate = newConfig.restrictions.minDate;
+      this.viewDate = newConfig.restrictions.minDate.clone;
   }
 
   /**


### PR DESCRIPTION
Probably this changes should be in V7. If this is the case, I will do the changes just le met know.
see issue:
#2877 

…
PRs relating to the v4 will be closed and locked.

* **Please check if the PR fulfills these requirements**
- [ ] The PR is against the `development` branch
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Does NOT modify files under the "dist" folder.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...). If this is a fix, please tag a bug.



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**
N/A


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
