### PR TITLE
Added full "Month only" mode

### DIFF
--- a/src/js/actions.ts
+++ b/src/js/actions.ts
@@ -55,7 +55,19 @@ export default class Actions {
         this.display._updateCalendarHeader();
         break;
       case ActionTypes.selectMonth:
+        lastPicked.month = +currentTarget.dataset.value;
+        this.dates.setValue(lastPicked, this.dates.lastPickedIndex);
+        if (this.optionsStore.options.display.viewMode === 'months') {
+          this.display.hide();
+          break;
+        }
+        this.handleSelectCalendarMode(action, currentTarget);
+        break;
       case ActionTypes.selectYear:
+        lastPicked.year = parseInt(currentTarget.dataset.value);
+        this.dates.setValue(lastPicked, this.dates.lastPickedIndex);
+        this.handleSelectCalendarMode(action, currentTarget);
+        break;
       case ActionTypes.selectDecade:
         this.handleSelectCalendarMode(action, currentTarget);
         break;

--- a/src/js/actions.ts
+++ b/src/js/actions.ts
@@ -352,7 +352,6 @@ export default class Actions {
 
   private handleMultiDate(day: DateTime) {
     let index = this.dates.pickedIndex(day, Unit.date);
-    console.log(index);
     if (index !== -1) {
       this.dates.setValue(null, index); //deselect multi-date
     } else {

--- a/src/js/actions.ts
+++ b/src/js/actions.ts
@@ -55,7 +55,7 @@ export default class Actions {
         this.display._updateCalendarHeader();
         break;
       case ActionTypes.selectMonth:
-        lastPicked.month = +currentTarget.dataset.value;
+        lastPicked.month = currentTarget.dataset.value;
         this.dates.setValue(lastPicked, this.dates.lastPickedIndex);
         if (this.optionsStore.options.display.viewMode === 'months') {
           this.display.hide();


### PR DESCRIPTION
PRs relating to the v4 will be closed and locked.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

In the previous version, although the parameter`display.viewMode` was `months`, after the month was selected the calendar for selecting the day was also displayed.