### PR TITLE
Fixed dayViewHeaderFormat

### DIFF
--- a/src/js/locales/pt-PT.ts
+++ b/src/js/locales/pt-PT.ts
@@ -27,7 +27,7 @@ const localization = {
   toggleMeridiem: 'Alterar AM/PM',
   selectTime: 'Selecionar hora',
   selectDate: 'Seleccionar data',
-  dayViewHeaderFormat: { month: 'longo', year: '2-digitos' },
+  dayViewHeaderFormat: { month: 'long', year: '2-digits' },
   startOfTheWeek: 1,
   locale: 'pt-PT',
   dateFormats: {


### PR DESCRIPTION
PRs relating to the v4 will be closed and locked.

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...). If this is a fix, please tag a bug.
Simple fix on the dayViewHeaderFormat: for some reason, the format parameters were in Portuguese instead of the expected English.


* **What is the current behavior?** (You can also link to an open issue here)
Current behavior throws an error, since the current configuration is not accepted by the API


* **What is the new behavior (if this is a feature change)?**
No longer throws an error


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes


* **Other information**:
The day names in Portuguese are too big for the calendar but it works