### PR TITLE
Fix display bug when selecting a date range

### DIFF
--- a/src/js/datetime.ts
+++ b/src/js/datetime.ts
@@ -938,7 +938,12 @@ export class DateTime extends Date {
       const y = year || dt.getFullYear();
       let M = 0;
       if (!(year && !month)) {
-        M = month > 0 ? month - 1 : dt.getMonth();
+        M =
+          month > 0
+            ? localization.monthZeroIndex
+              ? month
+              : month - 1
+            : dt.getMonth();
       }
       if (zone) {
         return new DateTime(

--- a/src/js/display/calendar/date-display.ts
+++ b/src/js/display/calendar/date-display.ts
@@ -179,6 +179,7 @@ export default class DateDisplay {
       // format the string to a date
       const innerDate = DateTime.fromString(attributeValue, {
         format: 'yyyy-MM-dd',
+        monthZeroIndex: true,
       });
 
       // find the position of the target in the date container
@@ -192,7 +193,7 @@ export default class DateDisplay {
 
       //format the start date so that it can be found by the attribute
       const rangeStartFormatted = this._dateToDataValue(rangeStart);
-      const rangeStartIndex = allDays.findIndex(
+      let rangeStartIndex = allDays.findIndex(
         (e) => e.getAttribute('data-value') === rangeStartFormatted
       );
       const rangeStartElement = allDays[rangeStartIndex];
@@ -214,6 +215,9 @@ export default class DateDisplay {
       let lambda: (_, index) => boolean;
 
       if (innerDate.isBefore(rangeStart)) {
+        if (rangeStartElement === undefined) {
+          rangeStartIndex = Number.MAX_SAFE_INTEGER;
+        }
         currentTarget.classList.add(Namespace.css.rangeStart);
         rangeStartElement?.classList.remove(Namespace.css.rangeStart);
         rangeStartElement?.classList.add(Namespace.css.rangeEnd);

--- a/src/js/utilities/options.ts
+++ b/src/js/utilities/options.ts
@@ -77,6 +77,7 @@ export interface FormatLocalization {
   hourCycle?: Intl.LocaleHourCycleKey;
   locale?: string;
   ordinal?: (n: number) => any; //eslint-disable-line @typescript-eslint/no-explicit-any
+  monthZeroIndex?: boolean;
 }
 
 export interface Localization extends FormatLocalization {

--- a/test/datetime.test.ts
+++ b/test/datetime.test.ts
@@ -75,6 +75,22 @@ test('Can create with string', () => {
   expect(dt.month).toBe(12 - 1); //minus 1 because javascript 🙄
   expect(dt.date).toBe(31);
   expect(dt.year).toBe(2022);
+
+  const zeroIndexMonthDt = DateTime.fromString('2024-11-01', {
+    format: 'yyyy-MM-dd',
+    monthZeroIndex: true,
+  });
+  expect(zeroIndexMonthDt.year).toBe(2024);
+  expect(zeroIndexMonthDt.month).toBe(11);
+  expect(zeroIndexMonthDt.date).toBe(1);
+
+  const nonZeroIndexMonthDt = DateTime.fromString('2024-11-01', {
+    format: 'yyyy-MM-dd',
+    monthZeroIndex: false,
+  });
+  expect(nonZeroIndexMonthDt.year).toBe(2024);
+  expect(nonZeroIndexMonthDt.month).toBe(10);
+  expect(nonZeroIndexMonthDt.date).toBe(1);
 });
 
 test('Can create clone', () => {


### PR DESCRIPTION
PRs relating to the v4 will be closed and locked.

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...). If this is a fix, please tag a bug.
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When using a picker with selectable date range, the CSS class "range-in" for dates between the selected- and hovered date are not shown for hovered dates after the selected date.
Furthermore the "range-start" and "range-end" CSS classes are not toggled correctly (as in they should turn around when hovering before or after the already selected date).


* **What is the new behavior (if this is a feature change)?**
While only the start date is selected, the dates between it and the hovered date should now correctly apply, regardless of if the hovered date is before, after, or not even in the same calendar view.

When selecting a date range, the start and end date should now face the correct direction depending on if the hovered date is before or after the already selected date.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
There should not be any breaking changes as this is purely a fix to already existing features.


* **Other information**:
[Stackblitz](https://tempus-dominus-v6-simple-setup-dpvrbjwt.stackblitz.io)
