### PR TITLE
Update pt-PT.ts to fix year format

### DIFF
--- a/src/js/locales/pt-PT.ts
+++ b/src/js/locales/pt-PT.ts
@@ -27,7 +27,7 @@ const localization = {
   toggleMeridiem: 'Alterar AM/PM',
   selectTime: 'Selecionar hora',
   selectDate: 'Seleccionar data',
-  dayViewHeaderFormat: { month: 'long', year: '2-digits' },
+  dayViewHeaderFormat: { month: 'long', year: '2-digit' },
   startOfTheWeek: 1,
   locale: 'pt-PT',
   dateFormats: {


### PR DESCRIPTION
"2-digits" is wrong and should be "2-digit". See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat

It crashes in latest Chrome as is.

This is a simple fix because Portuguese currently crashes Chrome latest version when attempting to format because it uses the wrong format name for year.