### PR TITLE
fix: Error when trying to change AM/PM before selecting a time

### DIFF
--- a/src/js/actions.ts
+++ b/src/js/actions.ts
@@ -113,7 +113,7 @@ export default class Actions {
         this.manipulateAndSet(
           lastPicked,
           Unit.hours,
-          this.dates.lastPicked.hours >= 12 ? -12 : 12
+          lastPicked.hours >= 12 ? -12 : 12
         );
         break;
       case ActionTypes.togglePicker:

--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -410,6 +410,14 @@ test('toggleMeridiem', () => {
   expect(dates.picked).toEqual([shouldBe.manipulate(12, Unit.hours)]);
   expect(hideSpy).not.toHaveBeenCalled();
   expect(isValidSpy).toHaveBeenCalled();
+
+  //before selecting a time
+  dates.clear();
+  actions.do(event, ActionTypes.toggleMeridiem);
+  expect(setValueSpy).toHaveBeenCalled();
+  expect(dates.picked).toEqual([shouldBe.manipulate(-12, Unit.hours)]);
+  expect(hideSpy).not.toHaveBeenCalled();
+  expect(isValidSpy).toHaveBeenCalled();
 });
 
 test('togglePicker', () => {


### PR DESCRIPTION
PRs relating to the v4 will be closed and locked.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...). If this is a fix, please tag a bug.
  - Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
#2908
  - You can reproduce the error by setting the display.buttons.clear: true option and switching AM/PM before selecting a time.


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  - No


* **Other information**:
